### PR TITLE
Release 1.0.4

### DIFF
--- a/roodmus/__init__.py
+++ b/roodmus/__init__.py
@@ -31,7 +31,7 @@ import subprocess
 
 from roodmus.constants import *
 
-__version__ = "1.0.3"  # plugin version
+__version__ = "1.0.4"  # plugin version
 _logo = "ccpem_logo.png"
 _references = ['roodmus2024']
 

--- a/roodmus/protocols/protocol_simulate_micrographs.py
+++ b/roodmus/protocols/protocol_simulate_micrographs.py
@@ -214,8 +214,8 @@ class ProtSimulateMicrographs(EMProtocol):
                 f"--centre_y {pixelSize * centreY} --centre_z {centreZ} --cuboid_length_x {pixelSize * nX} "
                 f"--cuboid_length_y {pixelSize * nY} --cuboid_length_z {iceThickness} --tqdm "
                 f"--nproc {self.numberOfThreads.get()} --electrons_per_angstrom {self.dose.get()} "
-                f"--c_10 {self.defocusAverage.get()} --c_10_stddev {self.defocusSTD.get()} "
-                f"--model {self._micModel[self.micModel.get()]}")
+                f"--c_10 {self.defocusAverage.get()} --c_10_stddev {self.defocusSTD.get()} ")
+                # f"--model {self._micModel[self.micModel.get()]}")  # FIXME: Currently a bug in Roodmus, to be added when fixed
 
         if self.usesGpu():
             gpuID = [str(elem) for elem in self.getGpuList()][0]


### PR DESCRIPTION
Reomve `model` parameter from the execution of Roomdus as ut currently introduces a bug on the defocus.